### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # zed-config
  
+UwU


### PR DESCRIPTION
With lots and lots of love.... The phrase “raining cats and dogs” originated in seventeenth-century England. During heavy rainstorms, many homeless animals would drown and float down the streets, giving the appearance that it had actually rained cats and dogs. 